### PR TITLE
Improve accessibility of win95 mock desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,8 @@
 This repository contains a very minimal mock desktop inspired by the look of Windows 95. It is implemented with HTML, CSS and a bit of JavaScript.
 
 To try it out, open `index.html` in a web browser.
+
+## Keyboard shortcuts
+
+- **Alt+S** – open the Start menu.
+- Use **Tab** to focus the Start button, then **Enter** or **Space** to activate it.

--- a/index.html
+++ b/index.html
@@ -8,11 +8,17 @@
 </head>
 <body>
     <div id="desktop">
-        <div id="icon-computer" class="icon">My Computer</div>
-        <div id="icon-trash" class="icon">Recycle Bin</div>
+        <figure id="icon-computer" class="icon">
+            <img src="https://via.placeholder.com/32?text=PC" alt="My Computer icon">
+            <figcaption>My Computer</figcaption>
+        </figure>
+        <figure id="icon-trash" class="icon">
+            <img src="https://via.placeholder.com/32?text=Bin" alt="Recycle Bin icon">
+            <figcaption>Recycle Bin</figcaption>
+        </figure>
     </div>
     <div id="taskbar">
-        <div id="start-button">Start</div>
+        <button id="start-button">Start</button>
     </div>
     <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -1,3 +1,13 @@
-document.getElementById('start-button').addEventListener('click', function() {
+const startButton = document.getElementById('start-button');
+
+startButton.addEventListener('click', function () {
     alert('Start menu clicked!');
+});
+
+// Trigger start menu with Alt+S
+document.addEventListener('keydown', function (e) {
+    if (e.altKey && e.key.toLowerCase() === 's') {
+        startButton.focus();
+        startButton.click();
+    }
 });

--- a/style.css
+++ b/style.css
@@ -21,6 +21,15 @@ body {
     margin-bottom: 10px;
 }
 
+.icon img {
+    display: block;
+    margin: 0 auto;
+}
+
+.icon figcaption {
+    margin-top: 4px;
+}
+
 #taskbar {
     position: absolute;
     left: 0;
@@ -42,4 +51,5 @@ body {
     border-right-color: #404040;
     margin-left: 5px;
     cursor: pointer;
+    font: inherit;
 }


### PR DESCRIPTION
## Summary
- add alt text and captions for desktop icons
- convert Start button to `<button>` for better accessibility
- allow opening Start menu with `Alt+S`
- document keyboard shortcuts

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68437dd652bc832c912831724f99cada