### PR TITLE
Fix start menu click handler

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,21 +1,13 @@
 const startButton = document.getElementById('start-button');
-
-
-startButton.addEventListener('click', function () {
-    alert('Start menu clicked!');
-
 const startMenu = document.getElementById('start-menu');
 
-startButton.addEventListener('click', function(event) {
+startButton.addEventListener('click', function (event) {
     event.stopPropagation();
-    if (startMenu.style.display === 'block') {
-        startMenu.style.display = 'none';
-    } else {
-        startMenu.style.display = 'block';
-    }
+    startMenu.style.display =
+        startMenu.style.display === 'block' ? 'none' : 'block';
 });
 
-document.addEventListener('click', function(event) {
+document.addEventListener('click', function (event) {
     if (!startMenu.contains(event.target) && event.target !== startButton) {
         startMenu.style.display = 'none';
     }


### PR DESCRIPTION
## Summary
- declare `startMenu` once at top
- add unified click handler that toggles the menu
- remove leftover incomplete listener

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6843f2bb83cc832c8e360c03a55d954b