### PR TITLE
Improve window stacking order

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,6 +1,12 @@
 const startButton = document.getElementById('start-button');
 const startMenu = document.getElementById('start-menu');
 
+let topZIndex = 1;
+
+function bringToFront(win) {
+    win.style.zIndex = ++topZIndex;
+}
+
 startButton.addEventListener('click', function (event) {
     event.stopPropagation();
     startMenu.style.display =
@@ -15,6 +21,7 @@ document.addEventListener('click', function (event) {
 
 function makeDraggable(win, handle) {
     handle.addEventListener('mousedown', function(e) {
+        bringToFront(win);
         const offsetX = e.clientX - win.offsetLeft;
         const offsetY = e.clientY - win.offsetTop;
 
@@ -38,6 +45,7 @@ function createWindow(title) {
     win.className = 'window';
     win.style.left = '100px';
     win.style.top = '100px';
+    bringToFront(win);
 
     const titleBar = document.createElement('div');
     titleBar.className = 'title-bar';
@@ -60,6 +68,8 @@ function createWindow(title) {
     win.appendChild(content);
 
     document.getElementById('desktop').appendChild(win);
+
+    win.addEventListener('mousedown', () => bringToFront(win));
 
     makeDraggable(win, titleBar);
 }

--- a/style.css
+++ b/style.css
@@ -39,6 +39,7 @@ body {
     width: 300px;
     height: 200px;
     box-sizing: border-box;
+    z-index: 1;
 }
 
 .title-bar {
@@ -80,6 +81,7 @@ body {
     box-shadow: 0 -2px 0 #808080 inset;
     display: flex;
     align-items: center;
+    z-index: 50;
 }
 
 #start-button {
@@ -107,6 +109,7 @@ body {
     border-bottom-color: #404040;
     border-right-color: #404040;
     display: none;
+    z-index: 100;
 }
 
 .menu-item {


### PR DESCRIPTION
## Summary
- ensure opened windows appear above others when clicked or dragged
- keep start menu and taskbar at consistent z-index layers

## Testing
- `npm test` *(fails: Missing script)*
- `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_684d04ccf880832c84e24087240a35d3